### PR TITLE
Support `source.babel` syntax

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -10,7 +10,7 @@ fs = require "fs"
 class LinterESLint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.js', 'source.js.jsx']
+  @syntax: ['source.js', 'source.js.jsx', 'source.babel']
 
   @disableWhenNoEslintrcFileInPath = false
 


### PR DESCRIPTION
This adds support for the `source.babel` syntax, provided by the package [language-babel](https://atom.io/packages/language-babel).
